### PR TITLE
Prevent AtlasLoot from breaking on non-existant loot table

### DIFF
--- a/AtlasLoot/Core/AtlasLoot.lua
+++ b/AtlasLoot/Core/AtlasLoot.lua
@@ -635,7 +635,7 @@ function AtlasLoot_ShowItemsFrame(dataID, dataSource, boss, pFrame)
         getglobal("AtlasLootItem_"..i).spellitemID = 0;
 	end
     
-    if AtlasLoot_TableNames[dataID][2] == "Menu" then
+    if AtlasLoot_TableNames[dataID] ~= nil and AtlasLoot_TableNames[dataID][2] == "Menu" then
         AtlasLoot_GenerateAtlasMenu(dataID, pFrame);
         return;
     end


### PR DESCRIPTION
### Description
When a loot table does not exists, and AtlasLoot tries to fetch it, the whole thing breaks. This change will prevent that and also writes out for the client on which table is missing, for example: "AtlasLoot Error! KaraAttumenHEROIC not listed in loot table registry, please report this message to the AtlasLoot forums at http://www.atlasloot.net/"