### PR TITLE
Feature/custom item filter 0.01

### DIFF
--- a/AtlasLoot/Core/Search.lua
+++ b/AtlasLoot/Core/Search.lua
@@ -133,28 +133,6 @@ local STATFILTERS = {
 	["resarc"] = "RESISTANCE6_NAME"
 };
 
--- Slash command that prints out all used item filter keys
-SLASH_ATLASLOOTITEMINFOFILTERS1 = "/atlaslootfilterkeys";
-SlashCmdList["ATLASLOOTITEMINFOFILTERS"] = function(msg, editBox)
-	local sortedTable = { "socket", "sockets", "gem", "gems", "ilvl" };
-	for index, statItem in pairs(STATFILTERS) do
-		table.insert(sortedTable, index);
-	end
-	table.sort(sortedTable, function(a,b) return a < b; end)
-
-	local filterKeys = "Filter keys: [ ";
-	for i, filterIndex in pairs(sortedTable) do
-		if i == 1 then
-			filterKeys = filterKeys..filterIndex;
-		else
-			filterKeys = filterKeys..", "..filterIndex;
-		end
-	end
-	filterKeys = filterKeys.." ]";
-	
-	print(filterKeys);
-end
-
 local ITEMSOCKETSTATFILTERS = {
 	"EMPTY_SOCKET_BLUE",
 	"EMPTY_SOCKET_RED",
@@ -221,6 +199,35 @@ local ITEMLEVELGEAREQUIPFILTER = {
 	["INVTYPE_AMMO"] = "INVTYPE_AMMO",
 	["INVTYPE_QUIVER"] = "INVTYPE_QUIVER"
 };
+
+-- Slash command that prints out all used item filter keys
+SLASH_ATLASLOOTITEMINFOFILTERS1 = "/atlaslootfilterkeys";
+SlashCmdList["ATLASLOOTITEMINFOFILTERS"] = function(msg, editBox)
+	local sortedTable = { "socket", "sockets", "gem", "gems", "ilvl" };
+	for index, statItem in pairs(STATFILTERS) do
+		table.insert(sortedTable, index);
+	end
+	table.sort(sortedTable, function(a,b) return a < b; end)
+
+	local filterKeys = "Filter keys: [ ";
+	for i, filterIndex in pairs(sortedTable) do
+		if i == 1 then
+			filterKeys = filterKeys..filterIndex;
+		else
+			filterKeys = filterKeys..", "..filterIndex;
+		end
+	end
+	filterKeys = filterKeys.." ]";
+	
+	print(filterKeys);
+end
+
+-- Slash command that prints filter examples
+SLASH_ATLASLOOTITEMINFOFILTEREXAMPLE1 = "/atlaslootfilterexample";
+SlashCmdList["ATLASLOOTITEMINFOFILTEREXAMPLE"] = function(msg, editBox)
+	print("Single search example: str>40");
+	print("Multi search example: str>40&ilvl<140&ilvl>=120&int>0&socket>2");
+end
 
 function AtlasLoot:ShowSearchResult()
 	AtlasLoot_ShowItemsFrame("SearchResult", "SearchResultPage"..currentPage, (AL["Search Result: %s"]):format(AtlasLootCharDB.LastSearchedText or ""), pFrame);
@@ -538,7 +545,9 @@ function AtlasLoot:Search(Text)
 		local itemFilterErrorMessage = "";
 		if operator then
 			itemFilterErrorMessage = [[
-Please check if you have a typo in the filter, to check filter keys, type "/atlaslootfilterkeys".
+Please check if you have a typo in the filter.
+To check filter keys, type "/atlaslootfilterkeys".
+To check filter examples, type "/atlaslootfilterexample".
 You might also have to query the server for item informations to load them into your client's Cache.]];
 		end
 		DEFAULT_CHAT_FRAME:AddMessage(RED..AL["AtlasLoot"]..": "..WHITE..AL["No match found for"].." \""..Text.."\"."..itemFilterErrorMessage);


### PR DESCRIPTION
### Description
Added the ability for the user to filter by item stats and item level

### Detailed Features
[Added] Stat filter
[Added] Item level filter
[Added] Filter by Total number of sockets
[Added] Slash command (/atlaslootfilterkeys) to display all used filter keys
[Added] Slash command (/atlaslootfilterexample) to display Single and Multi filter examples.
[Added] The ability to search by multiple filter keys by adding the "&" character in between filter parameters.

### Detailed error message on non-matching filter arguments
AtlasLoot: No match found for "str>40&ilvl<140&ilvl>=120&int>0&scocket>2".Please check if you have a typo in the filter.
To check filter keys, type "/atlaslootfilterkeys".
To check filter examples, type "/atlaslootfilterexample".
You might also have to query the server for item informations to load them into your client's Cache. 

### Used Filter Keys
agi, agility, ap, apferal, arm, armor, armorpen, armorpenetration, arp, attackpow, attackpower, attackpowerferal, attackpowferal, block, blockval, blockvalue, bv, crit, def, defense, dod, dodge, dps, exp, expertise, gem, gems, haste, health, hit, hp5, hpr, ilvl, int, intellect, mana, meta, mp5, mpr, parry, res, resarc, resarcane, resfire, resfrost, resholy, resil, resilience, resistancearcane, resistancefire, resistanceforst, resistanceholy, resistancenature, resistancephys, resistancephysical, resistanceshadow, resnat, resnature, resphys, resshad, resshadow, socket, socketblue, socketmeta, socketnocolor, socketred, sockets, socketwhite, socketyellow, sp, spellpen, spellpenetration, spellpow, spellpower, spi, spir, spirit, spp, sta, stam, stamina, str, strength

### Filter Examples Provided to the user
Single search example: str>40 
Multi search example: str>40&ilvl<140&ilvl>=120&int>0&socket>2